### PR TITLE
Add basic login/signup pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # MovieMatch
+
+This simple prototype includes login and signup pages with optional Google sign-in integration.
+
+## Getting Started
+
+1. Replace `YOUR_GOOGLE_CLIENT_ID` in `index.html` and `signup.html` with a valid client ID from the [Google Identity Services](https://developers.google.com/identity/gsi/web).
+2. Open `index.html` in a browser to test login.
+3. Open `signup.html` in a browser to test sign up.
+
+The forms currently display alert messages on submission. Integrate them with your backend to handle real authentication.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MovieMatch - Login</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+<body>
+    <h1>MovieMatch Login</h1>
+    <div class="form-container">
+        <form id="login-form">
+            <h2>Login</h2>
+            <label for="login-email">Email:</label>
+            <input type="email" id="login-email" name="email" required>
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" name="password" required>
+            <button type="submit">Login</button>
+        </form>
+        <div id="g_id_onload"
+             data-client_id="YOUR_GOOGLE_CLIENT_ID"
+             data-login_uri=""
+             data-auto_prompt="false">
+        </div>
+        <div class="g_id_signin" data-type="standard"></div>
+    </div>
+    <p>Don't have an account? <a href="signup.html">Sign Up</a></p>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,41 @@
+// Basic client-side handling for login and signup forms
+
+document.addEventListener('DOMContentLoaded', () => {
+    const loginForm = document.getElementById('login-form');
+    const signupForm = document.getElementById('signup-form');
+
+    if (loginForm) {
+        loginForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const email = loginForm.email.value;
+            const password = loginForm.password.value;
+            alert(`Login with ${email}`); // placeholder
+        });
+    }
+
+    if (signupForm) {
+        signupForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const name = signupForm.name.value;
+            const email = signupForm.email.value;
+            const password = signupForm.password.value;
+            alert(`Signup ${name} with ${email}`); // placeholder
+        });
+    }
+
+    // Initialize Google sign-in if client ID is provided
+    const clientId = document.getElementById('g_id_onload')?.dataset.client_id;
+    if (clientId && clientId !== 'YOUR_GOOGLE_CLIENT_ID') {
+        google.accounts.id.initialize({
+            client_id: clientId,
+            callback: (response) => {
+                console.log('Google token', response.credential);
+                alert('Google sign-in successful');
+            }
+        });
+        google.accounts.id.renderButton(
+            document.querySelector('.g_id_signin'),
+            { theme: 'outline', size: 'large' }
+        );
+    }
+});

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MovieMatch - Sign Up</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+<body>
+    <h1>MovieMatch Sign Up</h1>
+    <div class="form-container">
+        <form id="signup-form">
+            <h2>Create Account</h2>
+            <label for="signup-name">Name:</label>
+            <input type="text" id="signup-name" name="name" required>
+            <label for="signup-email">Email:</label>
+            <input type="email" id="signup-email" name="email" required>
+            <label for="signup-password">Password:</label>
+            <input type="password" id="signup-password" name="password" required>
+            <button type="submit">Sign Up</button>
+        </form>
+        <div id="g_id_onload"
+             data-client_id="YOUR_GOOGLE_CLIENT_ID"
+             data-login_uri=""
+             data-auto_prompt="false">
+        </div>
+        <div class="g_id_signin" data-type="standard"></div>
+    </div>
+    <p>Already have an account? <a href="index.html">Login</a></p>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,44 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    padding: 20px;
+}
+
+.form-container {
+    background: white;
+    padding: 20px;
+    max-width: 400px;
+    margin: auto;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+}
+
+label {
+    margin-top: 10px;
+}
+
+input {
+    padding: 8px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+}
+
+button {
+    margin-top: 15px;
+    padding: 10px;
+    background-color: #007BFF;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #0056b3;
+}


### PR DESCRIPTION
## Summary
- create login form with Google sign-in option
- create signup form with Google sign-in option
- add basic styling and JS handlers
- document how to configure Google sign-in

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ff6b9a018832784f7bd999bcc53a8