### PR TITLE
Add Firebase auth skeleton and basic navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/App.tsx
+++ b/App.tsx
@@ -1,71 +1,65 @@
-import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './src/screens/LoginScreen';
+import SignupScreen from './src/screens/SignupScreen';
+import HomeScreen from './src/screens/HomeScreen';
+import CreateRoomScreen from './src/screens/CreateRoomScreen';
+import JoinRoomScreen from './src/screens/JoinRoomScreen';
+import MovieSwipeScreen from './src/screens/MovieSwipeScreen';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-const LoginScreen = ({ onSignup }: { onSignup: () => void }) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  const handleLogin = () => {
-    // Add real login logic here
-    alert(`Logging in with ${email}`);
-  };
-
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Login</Text>
-      <TextInput value={email} onChangeText={setEmail} placeholder="Email" style={styles.input} />
-      <TextInput value={password} onChangeText={setPassword} placeholder="Password" secureTextEntry style={styles.input} />
-      <Button title="Login" onPress={handleLogin} />
-      <Button title="Go to Signup" onPress={onSignup} />
-    </View>
-  );
+export type RootStackParamList = {
+  Login: undefined;
+  Signup: undefined;
+  Home: undefined;
+  CreateRoom: undefined;
+  JoinRoom: undefined;
+  MovieSwipe: undefined;
 };
 
-const SignupScreen = ({ onBack }: { onBack: () => void }) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  const handleSignup = () => {
-    // Add real signup logic here
-    alert(`Signing up with ${email}`);
-  };
-
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Sign Up</Text>
-      <TextInput value={email} onChangeText={setEmail} placeholder="Email" style={styles.input} />
-      <TextInput value={password} onChangeText={setPassword} placeholder="Password" secureTextEntry style={styles.input} />
-      <Button title="Sign Up" onPress={handleSignup} />
-      <Button title="Back to Login" onPress={onBack} />
-    </View>
-  );
-};
+const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
-  const [showSignup, setShowSignup] = useState(false);
-  return showSignup ? (
-    <SignupScreen onBack={() => setShowSignup(false)} />
-  ) : (
-    <LoginScreen onSignup={() => setShowSignup(true)} />
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  const LoginWrapper = (props: NativeStackScreenProps<RootStackParamList, 'Login'>) => (
+    <LoginScreen onSignup={() => props.navigation.navigate('Signup')} onLoggedIn={() => setLoggedIn(true)} />
+  );
+
+  const SignupWrapper = (props: NativeStackScreenProps<RootStackParamList, 'Signup'>) => (
+    <SignupScreen onBack={() => props.navigation.goBack()} onSignedUp={() => setLoggedIn(true)} />
+  );
+
+  const HomeWrapper = (props: NativeStackScreenProps<RootStackParamList, 'Home'>) => (
+    <HomeScreen onCreateRoom={() => props.navigation.navigate('CreateRoom')} onJoinRoom={() => props.navigation.navigate('JoinRoom')} />
+  );
+
+  const CreateRoomWrapper = (props: NativeStackScreenProps<RootStackParamList, 'CreateRoom'>) => (
+    <CreateRoomScreen onRoomCreated={() => props.navigation.navigate('MovieSwipe')} />
+  );
+
+  const JoinRoomWrapper = (props: NativeStackScreenProps<RootStackParamList, 'JoinRoom'>) => (
+    <JoinRoomScreen onJoined={() => props.navigation.navigate('MovieSwipe')} />
+  );
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        {!loggedIn ? (
+          <>
+            <Stack.Screen name="Login" component={LoginWrapper} options={{ headerShown: false }} />
+            <Stack.Screen name="Signup" component={SignupWrapper} options={{ headerShown: false }} />
+          </>
+        ) : (
+          <>
+            <Stack.Screen name="Home" component={HomeWrapper} options={{ headerShown: false }} />
+            <Stack.Screen name="CreateRoom" component={CreateRoomWrapper} options={{ title: 'Create Room' }} />
+            <Stack.Screen name="JoinRoom" component={JoinRoomWrapper} options={{ title: 'Join Room' }} />
+            <Stack.Screen name="MovieSwipe" component={MovieSwipeScreen} options={{ title: 'Movies' }} />
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: 20
-  },
-  title: {
-    fontSize: 24,
-    marginBottom: 20,
-    textAlign: 'center'
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 10,
-    marginBottom: 10,
-    borderRadius: 4
-  }
-});

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # MovieMatch
 
-This project now uses React Native written in TypeScript. It provides simple login and signup screens to help you integrate authentication in a mobile app.
+This React Native app demonstrates a basic flow for a movie matching application.
+It uses Firebase for authentication and Firestore for storing room data. Movies
+are fetched from the TMDB API and presented with simple like/dislike buttons.
 
 ## Getting Started
 
-1. Install dependencies:
+1. Install dependencies
    ```bash
    npm install
    ```
-2. To run the Metro bundler:
+2. Start the Metro bundler
    ```bash
    npm start
    ```
-3. To launch on Android:
+3. Launch on Android
    ```bash
    npm run android
    ```
@@ -21,4 +23,5 @@ This project now uses React Native written in TypeScript. It provides simple log
    npm run ios
    ```
 
-The forms currently show alert messages on submission. Replace these with calls to your backend or add Google sign‑in as needed.
+Configure `src/firebase.ts` with your Firebase credentials and add a TMDB API key
+in `src/screens/MovieSwipeScreen.tsx` before running the app.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,16 @@
     "ios": "react-native run-ios"
   },
   "dependencies": {
+    "@react-native-masked-view/masked-view": "^0.3.2",
+    "@react-navigation/native": "^7.1.10",
+    "@react-navigation/native-stack": "^7.3.14",
+    "firebase": "^11.8.1",
     "react": "18.2.0",
-    "react-native": "0.73.7"
+    "react-native": "0.73.7",
+    "react-native-gesture-handler": "^2.25.0",
+    "react-native-reanimated": "^3.18.0",
+    "react-native-safe-area-context": "^5.4.1",
+    "react-native-screens": "^4.11.1"
   },
   "devDependencies": {
     "typescript": "5.4.5"

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,16 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_FIREBASE_API_KEY',
+  authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
+  projectId: 'YOUR_FIREBASE_PROJECT_ID',
+  storageBucket: 'YOUR_FIREBASE_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_FIREBASE_SENDER_ID',
+  appId: 'YOUR_FIREBASE_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/src/screens/CreateRoomScreen.tsx
+++ b/src/screens/CreateRoomScreen.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { collection, addDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function CreateRoomScreen({ onRoomCreated }: { onRoomCreated: (code: string) => void }) {
+  const [creating, setCreating] = useState(false);
+  const createRoom = async () => {
+    setCreating(true);
+    const code = Math.random().toString(36).substring(2, 8);
+    await addDoc(collection(db, 'rooms'), { code, createdAt: Date.now() });
+    onRoomCreated(code);
+  };
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Create Room</Text>
+      <Button title={creating ? 'Creating...' : 'Create'} onPress={createRoom} disabled={creating} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function HomeScreen({ onCreateRoom, onJoinRoom }: { onCreateRoom: () => void; onJoinRoom: () => void }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>MovieMatch</Text>
+      <Button title="Create Room" onPress={onCreateRoom} />
+      <Button title="Join Room" onPress={onJoinRoom} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/JoinRoomScreen.tsx
+++ b/src/screens/JoinRoomScreen.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function JoinRoomScreen({ onJoined }: { onJoined: (code: string) => void }) {
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+
+  const joinRoom = async () => {
+    const q = query(collection(db, 'rooms'), where('code', '==', code));
+    const snap = await getDocs(q);
+    if (!snap.empty) {
+      onJoined(code);
+    } else {
+      setError('Room not found');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Join Room</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TextInput value={code} onChangeText={setCode} placeholder="Room Code" style={styles.input} />
+      <Button title="Join" onPress={joinRoom} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 4,
+  },
+  error: {
+    color: 'red',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase';
+
+export default function LoginScreen({ onSignup, onLoggedIn }: { onSignup: () => void; onLoggedIn: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      onLoggedIn();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Login</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TextInput value={email} onChangeText={setEmail} placeholder="Email" style={styles.input} />
+      <TextInput value={password} onChangeText={setPassword} placeholder="Password" secureTextEntry style={styles.input} />
+      <Button title="Login" onPress={handleLogin} />
+      <Button title="Go to Signup" onPress={onSignup} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 4,
+  },
+  error: {
+    color: 'red',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/MovieSwipeScreen.tsx
+++ b/src/screens/MovieSwipeScreen.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Image, Button, StyleSheet, ActivityIndicator } from 'react-native';
+
+const API_KEY = 'YOUR_TMDB_API_KEY';
+
+interface Movie {
+  id: number;
+  title: string;
+  overview: string;
+  poster_path: string;
+}
+
+export default function MovieSwipeScreen() {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      try {
+        const res = await fetch(`https://api.themoviedb.org/3/trending/movie/week?api_key=${API_KEY}`);
+        const data = await res.json();
+        setMovies(data.results);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchMovies();
+  }, []);
+
+  if (movies.length === 0) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  const movie = movies[index];
+  const like = () => setIndex((i) => Math.min(i + 1, movies.length - 1));
+  const dislike = () => setIndex((i) => Math.min(i + 1, movies.length - 1));
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{movie.title}</Text>
+      {movie.poster_path ? (
+        <Image source={{ uri: `https://image.tmdb.org/t/p/w500${movie.poster_path}` }} style={styles.poster} />
+      ) : null}
+      <Text style={styles.overview}>{movie.overview}</Text>
+      <View style={styles.buttons}>
+        <Button title="Dislike" onPress={dislike} />
+        <Button title="Like" onPress={like} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  overview: {
+    marginVertical: 20,
+  },
+  poster: {
+    width: '100%',
+    height: 300,
+    resizeMode: 'contain',
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+});

--- a/src/screens/SignupScreen.tsx
+++ b/src/screens/SignupScreen.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase';
+
+export default function SignupScreen({ onBack, onSignedUp }: { onBack: () => void; onSignedUp: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSignup = async () => {
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+      onSignedUp();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Sign Up</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TextInput value={email} onChangeText={setEmail} placeholder="Email" style={styles.input} />
+      <TextInput value={password} onChangeText={setPassword} placeholder="Password" secureTextEntry style={styles.input} />
+      <Button title="Sign Up" onPress={handleSignup} />
+      <Button title="Back to Login" onPress={onBack} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 4,
+  },
+  error: {
+    color: 'red',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,22 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "esnext"],
-    "jsx": "react",
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "jsx": "react-jsx",
     "moduleResolution": "node",
     "allowJs": true,
     "noEmit": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add Firebase initialization
- create screens for login, signup, room creation/join and movie swiping
- integrate React Navigation and update app entry
- update TypeScript config and dependencies
- add project README instructions
- ignore `node_modules`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68410abfff0c8327b7ce4a799b2012a1