### PR TITLE
Fix TypeScript build error

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
 
   return (
     <NavigationContainer>
-      <Stack.Navigator>
+      <Stack.Navigator id={undefined}>
         {!loggedIn ? (
           <>
             <Stack.Screen name="Login" component={LoginWrapper} options={{ headerShown: false }} />

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "react-native-screens": "^4.11.1"
   },
   "devDependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-native": "^0.72.8",
     "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- install type definitions for React and React Native
- specify an explicit `id={undefined}` prop on `Stack.Navigator` to satisfy the type checker

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684116ea07fc8327a0aeb3adc70b01b9