### PR TITLE
Add IP access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ are fetched from the TMDB API and presented with simple like/dislike buttons.
    ```bash
    npm start
    ```
-3. Launch on Android
+3. Open `http://YOUR_IP:8081` from your phone to verify the server is reachable.
+4. Launch on Android
    ```bash
    npm run android
    ```
@@ -25,3 +26,38 @@ are fetched from the TMDB API and presented with simple like/dislike buttons.
 
 Configure `src/firebase.ts` with your Firebase credentials and add a TMDB API key
 in `src/screens/MovieSwipeScreen.tsx` before running the app.
+
+## Viewing on a Physical Device
+
+You can run the application directly on your phone instead of an emulator.
+
+### Android
+
+1. Enable **Developer options** and **USB debugging** on your Android device.
+2. Connect the phone with a USB cable and verify it appears via `adb devices`.
+3. Start the Metro bundler in one terminal:
+   ```bash
+   npm start
+   ```
+   Confirm your phone can reach `http://YOUR_IP:8081` from a browser on the device.
+4. In another terminal, build and deploy the app:
+   ```bash
+   npm run android
+   ```
+   If you encounter a connection error, run `adb reverse tcp:8081 tcp:8081` so your device can reach the bundler.
+
+### iOS
+
+1. Connect your iPhone via USB (macOS and Xcode are required).
+2. Start the Metro bundler:
+   ```bash
+   npm start
+   ```
+   Visit `http://YOUR_IP:8081` in Safari on your phone to ensure the bundler is accessible.
+3. Run the iOS project:
+   ```bash
+   npm run ios
+   ```
+   Make sure the phone and computer are on the same network so the bundle loads correctly.
+
+After the app launches on your device, shake it to open the React Native development menu.


### PR DESCRIPTION
## Summary
- document how to verify Metro server via phone
- note visiting `http://YOUR_IP:8081` when deploying on Android or iOS

## Testing
- `npm install`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68411b2a73c0832784868eef9a855f61