### PR TITLE
Add React Native specific ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 node_modules/
 package-lock.json
+
+# React Native
+android/build/
+ios/build/
+ios/Pods/
+*.iml


### PR DESCRIPTION
## Summary
- expand `.gitignore` with Android/iOS build paths and `*.iml`

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68412d4b7f18832791354ee956467133